### PR TITLE
Adding generic explore attributes functionality and toolbar button

### DIFF
--- a/gettags.js
+++ b/gettags.js
@@ -89,11 +89,11 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
 
 		// explore attributes for the different coremetrics tags
 		// get all query parameters matching ..._a99 pattern - pv_a99, pr_a99, s_a99, o_a99, etc.
-		var exploreAttributesPattern = /_a([\d]+)$/;
+		var exploreAttributesPattern = /(_a|rg)([\d]+)$/;
 		var exploreAttributes = Object.keys(queryString).filter( function(element) {return exploreAttributesPattern.test(element)} );
 		for (index=0; index<exploreAttributes.length; index++) { 
 			attributeName = exploreAttributes[index];
-			attributeNameIndex = exploreAttributesPattern.exec(attributeName)[1];
+			attributeNameIndex = exploreAttributesPattern.exec(attributeName)[2];
 			tabParams[attributeName]=queryString[attributeName] || '';
 		}
 

--- a/gettags.js
+++ b/gettags.js
@@ -82,6 +82,10 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
             "ecat": queryString['ecat'] || '', 
             "cd": queryString['cd'] || '',
             "em": queryString['em'] || '',
+			"ct": queryString['ct'] || '',
+			"sa": queryString['sa'] || '',
+			"zp": queryString['zp'] || '',
+			"cy": queryString['cy'] || '',
             "nl": queryString['nl'] || '',
             "sd": queryString['sd'] || ''
 

--- a/gettags.js
+++ b/gettags.js
@@ -47,7 +47,8 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
       // Should probably just change to send all of queryString.
       if (ourTabId) {
         console.log("Sending a message to the tab " + ourTabId);
-          chrome.tabs.sendMessage(ourTabId, {
+
+		var tabParams = {
             "siteUrl": siteUrl,
             "tagType": queryString['tid'] || '',  
             "clientId": queryString['ci'] || '',          
@@ -59,19 +60,6 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
             "libraryVersion": queryString['vn1'] || '',
             "productId": queryString['pr'] || '',
             "productName": queryString['pm'] || '',
-            "o_a1": queryString['o_a1'] || '', 
-            "at1": queryString['pr_a1'] || '', 
-            "at2": queryString['pr_a2'] || '', 
-            "at3": queryString['pr_a3'] || '', 
-            "at4": queryString['pr_a4'] || '', 
-            "at5": queryString['pr_a5'] || '', 
-            "at6": queryString['pr_a6'] || '',
-            "s1": queryString['s_a1'] || '', 
-            "s2": queryString['s_a2'] || '', 
-            "s3": queryString['s_a3'] || '', 
-            "s4": queryString['s_a4'] || '', 
-            "s5": queryString['s_a5'] || '', 
-            "s6": queryString['s_a6'] || '',
             "targetUrl": queryString['hr'] || '',
             "quantity": queryString['qt'] || '',
             "basePrice": queryString['bp'] || '',
@@ -95,7 +83,19 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
             "nl": queryString['nl'] || '',
             "sd": queryString['sd'] || ''
 
-          }, function(res){console.log(res);});  
+          };
+
+		// explore attributes for the different coremetrics tags
+		// get all query parameters matching ..._a99 pattern - pv_a99, pr_a99, s_a99, o_a99, etc.
+		var exploreAttributesPattern = /_a([\d]+)$/;
+		var exploreAttributes = Object.keys(queryString).filter( function(element) {return exploreAttributesPattern.test(element)} );
+		for (index=0; index<exploreAttributes.length; index++) { 
+			attributeName = exploreAttributes[index];
+			attributeNameIndex = exploreAttributesPattern.exec(attributeName)[1];
+			tabParams[attributeName]=queryString[attributeName] || '';
+		}
+
+        chrome.tabs.sendMessage(ourTabId, tabParams, function(res){console.log(res);});  
       }
     
     }

--- a/gettags.js
+++ b/gettags.js
@@ -1,15 +1,17 @@
 console.log('----------Coremetrics Tagbar for Chrome-----------');
 
 // Create the window to do the tagging in
-chrome.windows.create({
-    type: 'popup',
-    url: "tagwindow.html",
-    top: 100,
-    left: 100,
-    width: 800,
-    height: 760
-}, function (newWindow) {
-    console.log(newWindow);
+chrome.browserAction.onClicked.addListener(function(tab) {
+	chrome.windows.create({
+		type: 'popup',
+		url: "tagwindow.html",
+		top: 100,
+		left: 100,
+		width: 800,
+		height: 760
+	}, function (newWindow) {
+		console.log(newWindow);
+	});
 });
 
 var ourTabId;

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Coremetrics Bar for Chrome",
-  "version": "1.4",
+  "version": "1.5",
   "manifest_version": 2,
   "description": "This extension shows you all Coremetrics requests, allowing easier debugging of Coremetrics.",
   "icons": { "16": "icon16.png",

--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,9 @@
   ],
   "background": {
     "scripts": ["gettags.js"]
+  },
+  "browser_action": {
+    "default_icon": "icon.png",
+    "default_title": "Coremetrics Bar for Chrome"
   }
 }

--- a/tagwindow.js
+++ b/tagwindow.js
@@ -115,6 +115,10 @@ chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
       (request.referralUrl ? '<tr><td width="100px">Referral Url</td><td>' + request.referralUrl + '</td></tr>' : '') +
       (request.cd ? '<tr><td width="100px">Customer ID</td><td>' + request.cd + '</td></tr>' : '') +
       (request.em ? '<tr><td width="100px">Email</td><td>' + request.em + '</td></tr>' : '') +
+      (request.ct ? '<tr><td width="100px">City</td><td>' + request.ct + '</td></tr>' : '') +
+      (request.sa ? '<tr><td width="100px">State</td><td>' + request.sa + '</td></tr>' : '') +
+      (request.zp ? '<tr><td width="100px">Zip/Post Code</td><td>' + request.zp + '</td></tr>' : '') +
+      (request.cy ? '<tr><td width="100px">Country</td><td>' + request.cy + '</td></tr>' : '') +
       (request.nl ? '<tr><td width="100px">Newsletter Name</td><td>' + request.nl + '</td></tr>' : '') +
       (request.sd ? '<tr><td width="100px">Subscribed Flag</td><td>' + request.sd + '</td></tr>' : '') +
       (request.destinationUrl ? '<tr><td width="100px">Destination Url</td><td>' + request.destinationUrl + '</td></tr>' : '') +

--- a/tagwindow.js
+++ b/tagwindow.js
@@ -70,6 +70,9 @@ var tid_hash = { 1: "Page View Tag",
 
 chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
     var whichSite = request.destinationUrl.split('/')[2];
+	var exploreAttributesPattern = /_a([\d]+)$/;
+	var exploreAttributes = Object.keys(request).filter( function(element) {return exploreAttributesPattern.test(element)} );
+
    $('.dialfooter').prepend(
       '<div class="datagrid" site="' + whichSite + '" tagtype="' + request.tagType + '"><table>' + 
       '<thead><tr><th colspan="2">' + tid_hash[request.tagType] + ' (tid "'+ request.tagType + '")' + ' (' + request.siteUrl + ')</th></tr></thead>' +
@@ -89,19 +92,15 @@ chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
       (request.basePrice ? '<tr><td width="100px">Base Price</td><td>' + request.basePrice + '</td></tr>' : '') +
       (request.slotNumber ? '<tr><td width="100px">Slot Number</td><td>' + request.slotNumber + '</td></tr>' : '') +
       (request.actionType ? '<tr><td width="100px">Action Type</td><td>' + request.actionType + '</td></tr>' : '') +
-      (request.at1 ? '<tr><td width="100px">Attribute 1 (Explore)</td><td>' + request.at1 + '</td></tr>' : '') +
-      (request.at2 ? '<tr><td width="100px">Attribute 2 (Explore)</td><td>' + request.at2 + '</td></tr>' : '') +
-      (request.at3 ? '<tr><td width="100px">Attribute 3 (Explore)</td><td>' + request.at3 + '</td></tr>' : '') +
-      (request.at4 ? '<tr><td width="100px">Attribute 4 (Explore)</td><td>' + request.at4 + '</td></tr>' : '') +
-      (request.at5 ? '<tr><td width="100px">Attribute 5 (Explore)</td><td>' + request.at5 + '</td></tr>' : '') +
-      (request.at6 ? '<tr><td width="100px">Attribute 6 (Explore)</td><td>' + request.at6 + '</td></tr>' : '') +
-      (request.o_a1 ? '<tr><td width="100px">Attribute 1 (Explore)</td><td>' + request.o_a1 + '</td></tr>' : '') +
-      (request.s1 ? '<tr><td width="100px">Attribute 1 (Explore)</td><td>' + request.s1 + '</td></tr>' : '') +
-      (request.s2 ? '<tr><td width="100px">Attribute 2 (Explore)</td><td>' + request.s2 + '</td></tr>' : '') +
-      (request.s3 ? '<tr><td width="100px">Attribute 3 (Explore)</td><td>' + request.s3 + '</td></tr>' : '') +
-      (request.s4 ? '<tr><td width="100px">Attribute 4 (Explore)</td><td>' + request.s4 + '</td></tr>' : '') +
-      (request.s5 ? '<tr><td width="100px">Attribute 5 (Explore)</td><td>' + request.s5 + '</td></tr>' : '') +
-      (request.s6 ? '<tr><td width="100px">Attribute 6 (Explore)</td><td>' + request.s6 + '</td></tr>' : '') +
+	  (function() {
+		result = '';
+		for (index=0; index<exploreAttributes.length; index++) { 
+			attributeName = exploreAttributes[index];
+			attributeNameIndex = exploreAttributesPattern.exec(attributeName)[1];
+			result = result + (request[attributeName] ? '<tr><td width="100px">Attribute '+attributeNameIndex+' (Explore)</td><td>' + request[attributeName] + '</td></tr>' : '');
+		}
+		return result;
+      })() +
       (request.ps1 ? '<tr><td width="100px">Extra Field 1</td><td>' + request.ps1 + '</td></tr>' : '') +
       (request.ps2 ? '<tr><td width="100px">Extra Field 2</td><td>' + request.ps2 + '</td></tr>' : '') +
       (request.ps3 ? '<tr><td width="100px">Extra Field 3</td><td>' + request.ps3 + '</td></tr>' : '') +

--- a/tagwindow.js
+++ b/tagwindow.js
@@ -70,7 +70,7 @@ var tid_hash = { 1: "Page View Tag",
 
 chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
     var whichSite = request.destinationUrl.split('/')[2];
-	var exploreAttributesPattern = /_a([\d]+)$/;
+	var exploreAttributesPattern = /(_a|rg)([\d]+)$/;
 	var exploreAttributes = Object.keys(request).filter( function(element) {return exploreAttributesPattern.test(element)} );
 
    $('.dialfooter').prepend(
@@ -96,8 +96,8 @@ chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
 		result = '';
 		for (index=0; index<exploreAttributes.length; index++) { 
 			attributeName = exploreAttributes[index];
-			attributeNameIndex = exploreAttributesPattern.exec(attributeName)[1];
-			result = result + (request[attributeName] ? '<tr><td width="100px">Attribute '+attributeNameIndex+' (Explore)</td><td>' + request[attributeName] + '</td></tr>' : '');
+			attributeNameIndex = exploreAttributesPattern.exec(attributeName)[2];
+			result = result + (request[attributeName] ? '<tr><td width="100px">Attribute '+attributeNameIndex+' (Explore) ('+attributeName+')</td><td>' + request[attributeName] + '</td></tr>' : '');
 		}
 		return result;
       })() +


### PR DESCRIPTION
Basically, as different coremetrics tag send different parameters, and in our company we have up to 50 explore attributes (using about 45-50% of them per individual tags) I have added generic functionality that matches the parameters with a regular expression.

Let me know if any questions or concerns.
